### PR TITLE
improve libcpp compatibility

### DIFF
--- a/GraphicEQWidget/helpers/GainIterator.h
+++ b/GraphicEQWidget/helpers/GainIterator.h
@@ -32,7 +32,7 @@ struct FilterNode
 		this->dbGain = dbGain;
 	}
 
-	bool operator<(FilterNode other)
+	bool operator<(FilterNode other) const
 	{
 		return freq < other.freq;
 	}


### PR DESCRIPTION
Hi there, adding the 'const' keyword to the FilterNode comparator prevents a compiler error under clang-16 with libc++, as evidenced in the following log:

```
In file included from ../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUI.cpp:20:
In file included from /usr/include/c++/v1/vector:281:
In file included from /usr/include/c++/v1/__algorithm/copy.h:14:
In file included from /usr/include/c++/v1/__algorithm/min.h:12:
/usr/include/c++/v1/__algorithm/comp.h:47:71: error: invalid operands to binary expression ('const FilterNode' and 'const FilterNode')
    bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
                                                                  ~~~ ^ ~~~
/usr/include/c++/v1/__algorithm/sift_down.h:44:34: note: in instantiation of member function 'std::__less<FilterNode>::operator()' requested here
    if ((__child + 1) < __len && __comp(*__child_i, *(__child_i + difference_type(1)))) {
                                 ^
/usr/include/c++/v1/__algorithm/make_heap.h:36:14: note: in instantiation of function template specialization 'std::__sift_down<std::_ClassicAlgPolicy, std::__less<FilterNode> &,
      std::__wrap_iter<FilterNode *>>' requested here
        std::__sift_down<_AlgPolicy>(__first, __comp_ref, __n, __first + __start);
             ^
/usr/include/c++/v1/__algorithm/partial_sort.h:39:8: note: in instantiation of function template specialization 'std::__make_heap<std::_ClassicAlgPolicy, std::__less<FilterNode> &,
      std::__wrap_iter<FilterNode *>>' requested here
  std::__make_heap<_AlgPolicy>(__first, __middle, __comp);
       ^
/usr/include/c++/v1/__algorithm/partial_sort.h:66:12: note: in instantiation of function template specialization 'std::__partial_sort_impl<std::_ClassicAlgPolicy, std::__less<FilterNode> &,
      std::__wrap_iter<FilterNode *>, std::__wrap_iter<FilterNode *>>' requested here
      std::__partial_sort_impl<_AlgPolicy>(__first, __middle, __last, static_cast<__comp_ref_type<_Compare> >(__comp));
           ^
/usr/include/c++/v1/__algorithm/sort.h:693:10: note: in instantiation of function template specialization 'std::__partial_sort<std::_ClassicAlgPolicy, std::__less<FilterNode>,
      std::__wrap_iter<FilterNode *>, std::__wrap_iter<FilterNode *>>' requested here
    std::__partial_sort<_AlgPolicy>(__first, __last, __last, __comp);
         ^
/usr/include/c++/v1/__algorithm/sort.h:706:8: note: in instantiation of function template specialization 'std::__sort_impl<std::_ClassicAlgPolicy, std::__wrap_iter<FilterNode *>,
      std::__less<FilterNode>>' requested here
  std::__sort_impl<_ClassicAlgPolicy>(std::move(__first), std::move(__last), __comp);
       ^
/usr/include/c++/v1/__algorithm/sort.h:712:8: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<FilterNode *>, std::__less<FilterNode>>' requested here
  std::sort(__first, __last, __less<typename iterator_traits<_RandomAccessIterator>::value_type>());
       ^
../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUI.cpp:151:5: note: in instantiation of function template specialization 'std::sort<std::__wrap_iter<FilterNode *>>'
      requested here
    sort(nodes.begin(), nodes.end());
    ^
/usr/include/qt5/QtCore/qchar.h:65:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'char' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (char lhs, QLatin1Char rhs) noexcept { return lhs <  rhs.toLatin1(); }
                             ^
/usr/include/qt5/QtCore/qchar.h:72:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1Char' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (QLatin1Char lhs, char rhs) noexcept { return lhs.toLatin1() <  rhs; }
                             ^
/usr/include/qt5/QtCore/qchar.h:638:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (QChar c1, QChar c2) noexcept { return c1.ucs <  c2.ucs; }
                             ^
/usr/include/qt5/QtCore/qchar.h:647:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (QChar,     std::nullptr_t) noexcept { return false; }
                             ^
/usr/include/qt5/QtCore/qchar.h:649:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'std::nullptr_t' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (std::nullptr_t, QChar rhs) noexcept { return !rhs.isNull(); }
                             ^
/usr/include/qt5/QtCore/qbytearray.h:696:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QByteArray' for 1st argument
inline bool operator<(const QByteArray &a1, const QByteArray &a2) noexcept
            ^
/usr/include/qt5/QtCore/qbytearray.h:698:14: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QByteArray' for 1st argument
 inline bool operator<(const QByteArray &a1, const char *a2) noexcept
             ^
/usr/include/qt5/QtCore/qbytearray.h:700:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline bool operator<(const char *a1, const QByteArray &a2) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1390:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator<(QLatin1String s1, QLatin1String s2) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1434:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline QT_ASCII_CAST_WARN bool operator<(const char *s1, const QString &s2)
                               ^
/usr/include/qt5/QtCore/qstring.h:1447:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline QT_ASCII_CAST_WARN bool operator<(const char *s1, QLatin1String s2)
                               ^
/usr/include/qt5/QtCore/qstring.h:1824:20: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
Q_CORE_EXPORT bool operator<(const QStringRef &s1, const QStringRef &s2) noexcept;
                   ^
/usr/include/qt5/QtCore/qstring.h:1835:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QString' for 1st argument
inline bool operator< (const QString &lhs, const QStringRef &rhs) noexcept { return lhs.compare(rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1842:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline bool operator< (const QStringRef &lhs, const QString &rhs) noexcept { return rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1871:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator< (QLatin1String lhs, const QStringRef &rhs) noexcept { return rhs.compare(lhs) >  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1878:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline bool operator< (const QStringRef &lhs, QLatin1String rhs) noexcept { return rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1886:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, const QString &rhs) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1897:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QString' for 1st argument
inline bool operator< (const QString &lhs, QChar rhs) noexcept { return   rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1905:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, const QStringRef &rhs) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1916:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline bool operator< (const QStringRef &lhs, QChar rhs) noexcept { return   rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1924:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, QLatin1String rhs) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1935:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator< (QLatin1String lhs, QChar rhs) noexcept { return   rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1943:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QStringView' for 1st argument
inline bool operator< (QStringView lhs, QStringView rhs) noexcept { return QtPrivate::compareStrings(lhs, rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1951:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QStringView' for 1st argument
inline bool operator< (QStringView lhs, QChar rhs) noexcept { return lhs <  QStringView(&rhs, 1); }
            ^
/usr/include/qt5/QtCore/qstring.h:1958:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, QStringView rhs) noexcept { return QStringView(&lhs, 1) <  rhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1966:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QStringView' for 1st argument
inline bool operator< (QStringView lhs, QLatin1String rhs) noexcept { return QtPrivate::compareStrings(lhs, rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1973:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator< (QLatin1String lhs, QStringView rhs) noexcept { return QtPrivate::compareStrings(lhs, rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1982:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline QT_ASCII_CAST_WARN bool operator< (const QStringRef &lhs, const QByteArray &rhs) { return lhs.compare(rhs) <  0; }
                               ^
/usr/include/qt5/QtCore/qstring.h:1989:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QByteArray' for 1st argument
inline QT_ASCII_CAST_WARN bool operator< (const QByteArray &lhs, const QStringRef &rhs) { return rhs.compare(lhs) >  0; }
                               ^
/usr/include/qt5/QtCore/qstring.h:2012:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline QT_ASCII_CAST_WARN bool operator<(const char *s1, const QStringRef &s2)
                               ^
/usr/include/c++/v1/__utility/pair.h:444:1: note: candidate template ignored: could not match 'const pair<_T1, _T2>' against 'const FilterNode'
operator<=>(const pair<_T1,_T2>& __x, const pair<_T1,_T2>& __y)
^
/usr/include/qt5/QtCore/qpair.h:123:41: note: candidate template ignored: could not match 'const QPair<T1, T2>' against 'const FilterNode'
Q_DECL_CONSTEXPR Q_INLINE_TEMPLATE bool operator<(const QPair<T1, T2> &p1, const QPair<T1, T2> &p2)
                                        ^
/usr/include/qt5/QtCore/qvector.h:1087:6: note: candidate template ignored: could not match 'const QVector<T>' against 'const FilterNode'
bool operator<(const QVector<T> &lhs, const QVector<T> &rhs)
     ^
/usr/include/qt5/QtCore/qlist.h:1164:6: note: candidate template ignored: could not match 'const QList<T>' against 'const FilterNode'
bool operator<(const QList<T> &lhs, const QList<T> &rhs)
     ^
/usr/include/qt5/QtCore/qvarlengtharray.h:579:6: note: candidate template ignored: could not match 'const QVarLengthArray<T, Prealloc1>' against 'const FilterNode'
bool operator<(const QVarLengthArray<T, Prealloc1> &lhs, const QVarLengthArray<T, Prealloc2> &rhs)
     ^
/usr/include/qt5/QtCore/qsharedpointer_impl.h:866:24: note: candidate template ignored: could not match 'const QSharedPointer<T>' against 'const FilterNode'
Q_INLINE_TEMPLATE bool operator<(const QSharedPointer<T> &ptr1, const QSharedPointer<X> &ptr2)
                       ^
/usr/include/qt5/QtCore/qsharedpointer_impl.h:872:24: note: candidate template ignored: could not match 'const QSharedPointer<T>' against 'const FilterNode'
Q_INLINE_TEMPLATE bool operator<(const QSharedPointer<T> &ptr1, X *ptr2)
                       ^
/usr/include/qt5/QtCore/qsharedpointer_impl.h:878:24: note: candidate template ignored: could not match 'T *' against 'FilterNode'
Q_INLINE_TEMPLATE bool operator<(T *ptr1, const QSharedPointer<X> &ptr2)
                       ^
../../src/subprojects/GraphicEQWidget/GraphicEQWidget/helpers/GainIterator.h:35:7: note: candidate function not viable: 'this' argument has type 'const FilterNode', but method is not marked
      const
        bool operator<(FilterNode other)
             ^
In file included from ../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUIScene.cpp:20:
In file included from /usr/include/c++/v1/algorithm:1713:
In file included from /usr/include/c++/v1/__algorithm/adjacent_find.h:13:
/usr/include/c++/v1/__algorithm/comp.h:47:71: error: invalid operands to binary expression ('const FilterNode' and 'const FilterNode')
    bool operator()(const _T1& __x, const _T1& __y) const {return __x < __y;}
                                                                  ~~~ ^ ~~~
/usr/include/c++/v1/__functional/invoke.h:394:23: note: in instantiation of member function 'std::__less<FilterNode>::operator()' requested here
    { return          static_cast<_Fp&&>(__f)(static_cast<_Args&&>(__args)...); }
                      ^
/usr/include/c++/v1/__algorithm/lower_bound.h:40:14: note: in instantiation of function template specialization 'std::__invoke<std::__less<FilterNode> &, FilterNode &, const FilterNode &>'
      requested here
    if (std::__invoke(__comp, std::__invoke(__proj, *__m), __value)) {
             ^
/usr/include/c++/v1/__algorithm/lower_bound.h:56:15: note: in instantiation of function template specialization 'std::__lower_bound_impl<std::_ClassicAlgPolicy, std::__wrap_iter<FilterNode *>,
      std::__wrap_iter<FilterNode *>, FilterNode, std::__identity, std::__less<FilterNode>>' requested here
  return std::__lower_bound_impl<_ClassicAlgPolicy>(__first, __last, __value, __comp, __proj);
              ^
/usr/include/c++/v1/__algorithm/lower_bound.h:62:15: note: in instantiation of function template specialization 'std::lower_bound<std::__wrap_iter<FilterNode *>, FilterNode,
      std::__less<FilterNode>>' requested here
  return std::lower_bound(__first, __last, __value,
              ^
../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUIScene.cpp:63:36: note: in instantiation of function template specialization
      'std::lower_bound<std::__wrap_iter<FilterNode *>, FilterNode>' requested here
        vector<FilterNode>::iterator it = lower_bound(nodes.begin(), nodes.end(), node);
                                          ^
/usr/include/qt5/QtCore/qbytearray.h:696:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QByteArray' for 1st argument
inline bool operator<(const QByteArray &a1, const QByteArray &a2) noexcept
            ^
/usr/include/qt5/QtCore/qbytearray.h:698:14: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QByteArray' for 1st argument
 inline bool operator<(const QByteArray &a1, const char *a2) noexcept
             ^
/usr/include/qt5/QtCore/qbytearray.h:700:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline bool operator<(const char *a1, const QByteArray &a2) noexcept
            ^
/usr/include/qt5/QtCore/qchar.h:65:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'char' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (char lhs, QLatin1Char rhs) noexcept { return lhs <  rhs.toLatin1(); }
                             ^
/usr/include/qt5/QtCore/qchar.h:72:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1Char' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (QLatin1Char lhs, char rhs) noexcept { return lhs.toLatin1() <  rhs; }
                             ^
/usr/include/qt5/QtCore/qchar.h:638:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (QChar c1, QChar c2) noexcept { return c1.ucs <  c2.ucs; }
                             ^
/usr/include/qt5/QtCore/qchar.h:647:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (QChar,     std::nullptr_t) noexcept { return false; }
                             ^
/usr/include/qt5/QtCore/qchar.h:649:30: note: candidate function not viable: no known conversion from 'const FilterNode' to 'std::nullptr_t' for 1st argument
Q_DECL_CONSTEXPR inline bool operator< (std::nullptr_t, QChar rhs) noexcept { return !rhs.isNull(); }
                             ^
/usr/include/qt5/QtCore/qstring.h:1390:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator<(QLatin1String s1, QLatin1String s2) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1434:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline QT_ASCII_CAST_WARN bool operator<(const char *s1, const QString &s2)
                               ^
/usr/include/qt5/QtCore/qstring.h:1447:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline QT_ASCII_CAST_WARN bool operator<(const char *s1, QLatin1String s2)
                               ^
/usr/include/qt5/QtCore/qstring.h:1824:20: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
Q_CORE_EXPORT bool operator<(const QStringRef &s1, const QStringRef &s2) noexcept;
                   ^
/usr/include/qt5/QtCore/qstring.h:1835:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QString' for 1st argument
inline bool operator< (const QString &lhs, const QStringRef &rhs) noexcept { return lhs.compare(rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1842:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline bool operator< (const QStringRef &lhs, const QString &rhs) noexcept { return rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1871:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator< (QLatin1String lhs, const QStringRef &rhs) noexcept { return rhs.compare(lhs) >  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1878:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline bool operator< (const QStringRef &lhs, QLatin1String rhs) noexcept { return rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1886:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, const QString &rhs) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1897:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QString' for 1st argument
inline bool operator< (const QString &lhs, QChar rhs) noexcept { return   rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1905:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, const QStringRef &rhs) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1916:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline bool operator< (const QStringRef &lhs, QChar rhs) noexcept { return   rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1924:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, QLatin1String rhs) noexcept
            ^
/usr/include/qt5/QtCore/qstring.h:1935:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator< (QLatin1String lhs, QChar rhs) noexcept { return   rhs >  lhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1943:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QStringView' for 1st argument
inline bool operator< (QStringView lhs, QStringView rhs) noexcept { return QtPrivate::compareStrings(lhs, rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1951:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QStringView' for 1st argument
inline bool operator< (QStringView lhs, QChar rhs) noexcept { return lhs <  QStringView(&rhs, 1); }
            ^
/usr/include/qt5/QtCore/qstring.h:1958:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QChar' for 1st argument
inline bool operator< (QChar lhs, QStringView rhs) noexcept { return QStringView(&lhs, 1) <  rhs; }
            ^
/usr/include/qt5/QtCore/qstring.h:1966:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QStringView' for 1st argument
inline bool operator< (QStringView lhs, QLatin1String rhs) noexcept { return QtPrivate::compareStrings(lhs, rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1973:13: note: candidate function not viable: no known conversion from 'const FilterNode' to 'QLatin1String' for 1st argument
inline bool operator< (QLatin1String lhs, QStringView rhs) noexcept { return QtPrivate::compareStrings(lhs, rhs) <  0; }
            ^
/usr/include/qt5/QtCore/qstring.h:1982:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QStringRef' for 1st argument
inline QT_ASCII_CAST_WARN bool operator< (const QStringRef &lhs, const QByteArray &rhs) { return lhs.compare(rhs) <  0; }
                               ^
/usr/include/qt5/QtCore/qstring.h:1989:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const QByteArray' for 1st argument
inline QT_ASCII_CAST_WARN bool operator< (const QByteArray &lhs, const QStringRef &rhs) { return rhs.compare(lhs) >  0; }
                               ^
/usr/include/qt5/QtCore/qstring.h:2012:32: note: candidate function not viable: no known conversion from 'const FilterNode' to 'const char *' for 1st argument
inline QT_ASCII_CAST_WARN bool operator<(const char *s1, const QStringRef &s2)
                               ^
/usr/include/qt5/QtCore/qpair.h:123:41: note: candidate template ignored: could not match 'const QPair<T1, T2>' against 'const FilterNode'
Q_DECL_CONSTEXPR Q_INLINE_TEMPLATE bool operator<(const QPair<T1, T2> &p1, const QPair<T1, T2> &p2)
                                        ^
/usr/include/qt5/QtCore/qvector.h:1087:6: note: candidate template ignored: could not match 'const QVector<T>' against 'const FilterNode'
bool operator<(const QVector<T> &lhs, const QVector<T> &rhs)
     ^
/usr/include/qt5/QtCore/qlist.h:1164:6: note: candidate template ignored: could not match 'const QList<T>' against 'const FilterNode'
bool operator<(const QList<T> &lhs, const QList<T> &rhs)
     ^
/usr/include/qt5/QtCore/qvarlengtharray.h:579:6: note: candidate template ignored: could not match 'const QVarLengthArray<T, Prealloc1>' against 'const FilterNode'
bool operator<(const QVarLengthArray<T, Prealloc1> &lhs, const QVarLengthArray<T, Prealloc2> &rhs)
     ^
/usr/include/qt5/QtCore/qsharedpointer_impl.h:866:24: note: candidate template ignored: could not match 'const QSharedPointer<T>' against 'const FilterNode'
Q_INLINE_TEMPLATE bool operator<(const QSharedPointer<T> &ptr1, const QSharedPointer<X> &ptr2)
                       ^
/usr/include/qt5/QtCore/qsharedpointer_impl.h:872:24: note: candidate template ignored: could not match 'const QSharedPointer<T>' against 'const FilterNode'
Q_INLINE_TEMPLATE bool operator<(const QSharedPointer<T> &ptr1, X *ptr2)
                       ^
/usr/include/qt5/QtCore/qsharedpointer_impl.h:878:24: note: candidate template ignored: could not match 'T *' against 'FilterNode'
Q_INLINE_TEMPLATE bool operator<(T *ptr1, const QSharedPointer<X> &ptr2)
                       ^
../../src/subprojects/GraphicEQWidget/GraphicEQWidget/helpers/GainIterator.h:35:7: note: candidate function not viable: 'this' argument has type 'const FilterNode', but method is not marked
      const
        bool operator<(FilterNode other)
             ^
In file included from ../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUI.cpp:20:
In file included from /usr/include/c++/v1/vector:3359:
In file included from /usr/include/c++/v1/algorithm:1771:
In file included from /usr/include/c++/v1/__algorithm/nth_element.h:15:
/usr/include/c++/v1/__algorithm/sort.h:250:3: error: no matching function for call to '__sort3'
  std::__sort3<_AlgPolicy, _Compare>(__x1, __x2, __x3, __c);
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/__algorithm/sort.h:452:12: note: in instantiation of function template specialization 'std::__sort3_maybe_branchless<std::_ClassicAlgPolicy, std::__less<FilterNode> &,
      FilterNode *>' requested here
      std::__sort3_maybe_branchless<_AlgPolicy, _Compare>(__first, __first + difference_type(1), --__last, __comp);
           ^
/usr/include/c++/v1/__algorithm/sort.h:639:8: note: in instantiation of function template specialization 'std::__introsort<std::_ClassicAlgPolicy, std::__less<FilterNode> &, FilterNode *>'
      requested here
  std::__introsort<_AlgPolicy, _Compare>(__first, __last, __comp, __depth_limit);
       ^
/usr/include/c++/v1/__algorithm/sort.h:699:10: note: in instantiation of function template specialization 'std::__sort<std::__less<FilterNode> &, FilterNode *>' requested here
    std::__sort<_WrappedComp>(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __wrapped_comp);
         ^
/usr/include/c++/v1/__algorithm/sort.h:90:40: note: candidate template ignored: substitution failure [with _AlgPolicy = std::_ClassicAlgPolicy, _Compare = std::__less<FilterNode> &,
      _ForwardIterator = FilterNode *]
_LIBCPP_CONSTEXPR_SINCE_CXX14 unsigned __sort3(_ForwardIterator __x, _ForwardIterator __y, _ForwardIterator __z,
                                       ^
/usr/include/c++/v1/__algorithm/sort.h:133:18: error: no matching function for call to '__sort3'
  unsigned __r = std::__sort3<_AlgPolicy, _Compare>(__x1, __x2, __x3, __c);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/__algorithm/sort.h:268:8: note: in instantiation of function template specialization 'std::__sort4<std::_ClassicAlgPolicy, std::__less<FilterNode> &, FilterNode *>'
      requested here
  std::__sort4<_AlgPolicy, _Compare>(__x1, __x2, __x3, __x4, __c);
       ^
/usr/include/c++/v1/__algorithm/sort.h:455:12: note: in instantiation of function template specialization 'std::__sort4_maybe_branchless<std::_ClassicAlgPolicy, std::__less<FilterNode> &,
      FilterNode *>' requested here
      std::__sort4_maybe_branchless<_AlgPolicy, _Compare>(
           ^
/usr/include/c++/v1/__algorithm/sort.h:639:8: note: in instantiation of function template specialization 'std::__introsort<std::_ClassicAlgPolicy, std::__less<FilterNode> &, FilterNode *>'
      requested here
  std::__introsort<_AlgPolicy, _Compare>(__first, __last, __comp, __depth_limit);
       ^
/usr/include/c++/v1/__algorithm/sort.h:699:10: note: in instantiation of function template specialization 'std::__sort<std::__less<FilterNode> &, FilterNode *>' requested here
    std::__sort<_WrappedComp>(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __wrapped_comp);
         ^
/usr/include/c++/v1/__algorithm/sort.h:90:40: note: candidate template ignored: substitution failure [with _AlgPolicy = std::_ClassicAlgPolicy, _Compare = std::__less<FilterNode> &,
      _ForwardIterator = FilterNode *]
_LIBCPP_CONSTEXPR_SINCE_CXX14 unsigned __sort3(_ForwardIterator __x, _ForwardIterator __y, _ForwardIterator __z,
                                       ^
/usr/include/c++/v1/__algorithm/sort.h:161:18: error: no matching function for call to '__sort4'
  unsigned __r = std::__sort4<_AlgPolicy, _Compare>(__x1, __x2, __x3, __x4, __c);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/__algorithm/sort.h:187:15: note: in instantiation of function template specialization 'std::__sort5<std::__less<FilterNode> &, FilterNode *>' requested here
  return std::__sort5<_WrappedComp>(
              ^
/usr/include/c++/v1/__algorithm/sort.h:485:26: note: in instantiation of function template specialization 'std::__sort5_wrap_policy<std::_ClassicAlgPolicy, std::__less<FilterNode> &,
      FilterNode *>' requested here
        __n_swaps = std::__sort5_wrap_policy<_AlgPolicy, _Compare>(
                         ^
/usr/include/c++/v1/__algorithm/sort.h:639:8: note: in instantiation of function template specialization 'std::__introsort<std::_ClassicAlgPolicy, std::__less<FilterNode> &, FilterNode *>'
      requested here
  std::__introsort<_AlgPolicy, _Compare>(__first, __last, __comp, __depth_limit);
       ^
/usr/include/c++/v1/__algorithm/sort.h:699:10: note: in instantiation of function template specialization 'std::__sort<std::__less<FilterNode> &, FilterNode *>' requested here
    std::__sort<_WrappedComp>(std::__unwrap_iter(__first), std::__unwrap_iter(__last), __wrapped_comp);
         ^
/usr/include/c++/v1/__algorithm/sort.h:129:10: note: candidate template ignored: substitution failure [with _AlgPolicy = _AlgPolicy, _Compare = _Compare, _ForwardIterator = FilterNode *]
unsigned __sort4(_ForwardIterator __x1, _ForwardIterator __x2, _ForwardIterator __x3, _ForwardIterator __x4,
         ^
1 warning and 1 error generated.
make[1]: *** [Makefile:3352: GraphicEQFilterGUIScene.o] Error 1
make[1]: *** Waiting for unfinished jobs....
1 warning and 4 errors generated.
make[1]: *** [Makefile:3333: GraphicEQFilterGUI.o] Error 1
In file included from ../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUIView.cpp:20:
In file included from ../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUIScene.h:26:
../../src/subprojects/GraphicEQWidget/GraphicEQWidget/GraphicEQFilterGUIItem.h:30:14: warning: 'type' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
        virtual int type() const
                    ^
../../src/subprojects/GraphicEQWidget/GraphicEQWidget/widgets/FrequencyPlotItem.h:30:14: note: overridden virtual function is here
        virtual int type() const
                    ^
1 warning generated.
```

Hopefully you'll accept the change.